### PR TITLE
Report git version with library_version

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -18,6 +18,10 @@ endif
 EXTERNAL_ZLIB = 0
 
 TARGET_NAME	:= hatari
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 
 ifeq ($(platform), unix)
 	TARGET := $(TARGET_NAME)_libretro.so

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -252,7 +252,10 @@ void retro_get_system_info(struct retro_system_info *info)
 {
    memset(info, 0, sizeof(*info));
    info->library_name     = "Hatari";
-   info->library_version  = "1.8";
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+   info->library_version  = "1.8" GIT_VERSION;
    info->valid_extensions = "ST|MSA|ZIP|STX|DIM|IPF";
    info->need_fullpath    = true;
    info->block_extract = false;


### PR DESCRIPTION
This patch makes this core report the git version along with its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.