### PR TITLE
apply madmonkey crash fix - add build instructions to readme

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -26,10 +26,13 @@ ifneq ($(GIT_VERSION)," unknown")
 endif
 
 ifeq ($(platform), unix)
-	TARGET := $(TARGET_NAME)_libretro.so
+   TARGET := $(TARGET_NAME)_libretro.so
    fpic := -fPIC
-   SHARED :=  -lz -lpthread -shared -Wl,--version-script=$(LIBRETRO_DIR)/link.T -Wl,--no-undefined
+   SHARED :=  -lm -lz -lpthread -shared -Wl,--version-script=$(LIBRETRO_DIR)/link.T -Wl,--no-undefined -Wl,--as-needed
    PLATFLAGS := -DLSB_FIRST -DALIGN_DWORD
+ifeq ($(ARCH), arm)
+   CFLAGS += -mno-unaligned-access
+endif
 else ifeq ($(platform), android)
    CC = arm-linux-androideabi-gcc
    AR = @arm-linux-androideabi-ar
@@ -147,17 +150,16 @@ else
 endif
 
 ifeq ($(DEBUG), 1)
-   CFLAGS += -O0 -g
+   CFLAGS := $(CFLAGS) -Og -g
 else
-   CFLAGS += -O3
+   CFLAGS := -funroll-loops -ffast-math -fomit-frame-pointer $(CFLAGS) -O3
 endif
+CFLAGS := -fsigned-char -D__LIBRETRO__ -fno-builtin $(CFLAGS)
 
-CFLAGS += \
-	-std=gnu99 -funroll-loops  -fsigned-char -D__LIBRETRO__ \
-	-Wno-strict-prototypes -ffast-math -fomit-frame-pointer -fno-builtin
-
-CXXFLAGS  += $(CFLAGS)
-CPPFLAGS  += $(CFLAGS)
+CFLAGS := $(fpic) $(CFLAGS) $(PLATFLAGS)
+CXXFLAGS := $(CFLAGS)
+CPPFLAGS := $(CFLAGS)
+CFLAGS := -std=gnu99 $(CFLAGS)
 
 EMU = $(CORE_DIR)/src
 CPU = $(EMU)/uae-cpu
@@ -180,12 +182,12 @@ $(TARGET): $(OBJECTS)
 ifeq ($(STATIC_LINKING_LINK),1)
 	$(AR) rcs $@ $(OBJECTS) 
 else
-	$(CC) $(fpic) $(INCLUDES) -o $@ $(OBJECTS)  -lm -lz $(SHARED)
+	$(CC) $(CFLAGS) $(INCFLAGS) -lm -lz $(SHARED) $(LDFLAGS) $(OBJECTS) -o $@
 endif
 	@echo "** BUILD SUCCESSFUL! GG NO RE **"
 
 %.o: %.c
-	$(CC) $(fpic) $(CFLAGS) $(PLATFLAGS) $(INCFLAGS) -c -o $@ $<
+	$(CC) $(CFLAGS) $(INCFLAGS) -c -o $@ $<
 
 clean:
 	rm -f $(OBJECTS) $(TARGET) 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # HATARI LIBRETRO
 
-Hatari is an Atari ST/STE/TT/Falcon emulator for Linux, FreeBSD, NetBSD,
-BeOS, Mac-OSX and other Systems which are supported by the SDL library.
-Unlike most other open source ST emulators which try to give you a good
-environment for running GEM applications, Hatari tries to emulate the hardware
-as close as possible so that it is able to run most of the old Atari games
-and demos.  Because of this, it may be somewhat slower than less accurate
-emulators.
+Hatari is an Atari ST/STE/TT/Falcon emulator for Linux, FreeBSD, NetBSD, BeOS, Mac-OSX and other Systems which are supported by the SDL library.
 
-The homepage of hatari : http://hatari.tuxfamily.org/index.html
+Unlike most other open source ST emulators which try to give you a good environment for running GEM applications, Hatari tries to emulate the hardware as close as possible so that it is able to run most of the old Atari games and demos.  Because of this, it may be somewhat slower than less accurate emulators.
 
-Based on https://hg.tuxfamily.org/mercurialroot/hatari/hatari
+Hatari homepage: http://hatari.tuxfamily.org/index.html
+Shallow fork of: https://hg.tuxfamily.org/mercurialroot/hatari/hatari
+
+## Building Hatari-libretro
+```
+git clone http://github.com/libretro/hatari
+cd hatari
+make -f Makefile.libretro EXTERNAL_ZLIB=1
+```
 
 ## The Atari ST
 

--- a/libretro/hatari-mapper.c
+++ b/libretro/hatari-mapper.c
@@ -33,7 +33,7 @@ extern int Reset_Cold(void);
 #endif
 
 long frame=0;
-long  Ktime=0 , LastFPSTime=0;
+static unsigned long Ktime=0, LastFPSTime=0;
 
 //VIDEO
 extern SDL_Surface *sdlscrn; 

--- a/libretro/libretro-sdk/libco/armeabi.c
+++ b/libretro/libretro-sdk/libco/armeabi.c
@@ -22,19 +22,19 @@ extern "C" {
 static thread_local uint32_t co_active_buffer[64];
 static thread_local cothread_t co_active_handle;
 
-asm (
-      ".arm\n"
-      ".align 4\n"
+__asm__ (
+      "\n"
+      ".text\n"
       ".globl co_switch_arm\n"
-      ".globl _co_switch_arm\n"
+      ".type co_switch_arm,STT_FUNC\n"
+      ".p2align 4\n"
       "co_switch_arm:\n"
-      "_co_switch_arm:\n"      
       "  stmia r1!, {r4, r5, r6, r7, r8, r9, r10, r11, sp, lr}\n"
       "  ldmia r0!, {r4, r5, r6, r7, r8, r9, r10, r11, sp, pc}\n"
     );
 
 /* ASM */
-void co_switch_arm(cothread_t handle, cothread_t current);
+extern void co_switch_arm(cothread_t handle, cothread_t current);
 
 static void crash(void)
 {
@@ -66,7 +66,7 @@ cothread_t co_create(unsigned int size, void (*entrypoint)(void))
    ptr[5] = 0; /* r9  */
    ptr[6] = 0; /* r10 */
    ptr[7] = 0; /* r11 */
-   ptr[8] = (uintptr_t)ptr + size + 256 - 4; /* r13, stack pointer */
+   ptr[8] = (uintptr_t)ptr + size + 256; /* r13, stack pointer */
    ptr[9] = (uintptr_t)entrypoint; /* r15, PC (link register r14 gets saved here). */
    return handle;
 }

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -141,12 +141,11 @@ void Emu_init()
    memset(Key_Sate,0,512);
    memset(Key_Sate2,0,512);
 
-   if(!emuThread && !mainThread)
-   {
+   if(!emuThread)
       mainThread = co_active();
-      emuThread = co_create(65536*sizeof(void*), retro_wrap_emulator);
-   }
 
+   if(!emuThread)
+      emuThread = co_create(65536*sizeof(void*), retro_wrap_emulator);
 }
 
 void Emu_uninit()
@@ -358,15 +357,18 @@ void retro_deinit(void)
    Emu_uninit(); 
 
    if(emuThread)
-   {	 
+   {
       co_delete(emuThread);
       emuThread = 0;
    }
 
 	// Clean the m3u storage
 	if(dc)
+	{
 		dc_free(dc);
-   
+		dc = 0;
+	}
+
    LOGI("Retro DeInit\n");
 }
 


### PR DESCRIPTION
This is the patch that madmonkey posted to the libretro discord server and asked to have applied to Hatari.

They have tested it on one ARM system where it fixes the crash, and I have tested it with Windows 10 x64 D3D10 where it also fixes the crash. Therefore this should close two issues: https://github.com/libretro/hatari/issues/29 and https://github.com/libretro/hatari/issues/18