### PR TITLE
sound.c type mismatch, possible out of bound read? 

### DIFF
--- a/src/sound.c
+++ b/src/sound.c
@@ -1441,67 +1441,74 @@ void Sound_Update(bool FillFrame)
 extern short signed int SNDBUF[1024*2];
 static void Retro_Audio_CallBack(int len)
 {
-Sint16 *pBuffer;
-int i, window, nSamplesPerFrame;
-pBuffer = (Sint16 *)&SNDBUF[0];
-len = len / 4; // Use length in samples (16 bit stereo), not in bytes
-/* Adjust emulation rate within +/- 0.58% (10 cents) occasionally,
-* to synchronize sound. Note that an octave (frequency doubling)
-* has 12 semitones (12th root of two for a semitone), and that
-* one semitone has 100 cents (1200th root of two for one cent).
-* Ten cents are desired, thus, the 120th root of two minus one is
-* multiplied by 1,000,000 to convert to microseconds, and divided
-* by nScreenRefreshRate=60 to get a 96 microseconds swallow size.
-* (2^(10cents/(12semitones*100cents)) - 1) * 10^6 / nScreenRefreshRate
-* See: main.c - Main_WaitOnVbl()
-*/
-pulse_swallowing_count = 0; /* 0 = Unaltered emulation rate */
-if (ConfigureParams.Sound.bEnableSoundSync)
-{
-/* Sound synchronized emulation */
-nSamplesPerFrame = nAudioFrequency/nScreenRefreshRate;
-window = (nSamplesPerFrame > SoundBufferSize) ? nSamplesPerFrame : SoundBufferSize;
-/* Window Comparator for SoundBufferSize */
-if (nGeneratedSamples < window + (window >> 1))
-/* Increase emulation rate to maintain sound synchronization */
-pulse_swallowing_count = -5793 / nScreenRefreshRate;
-else
-if (nGeneratedSamples > (window << 1) + (window >> 2))
-/* Decrease emulation rate to maintain sound synchronization */
-pulse_swallowing_count = 5793 / nScreenRefreshRate;
-/* Otherwise emulation rate is unaltered. */
-}
-if (nGeneratedSamples >= len)
-{
-/* Enough samples available: Pass completed buffer to audio system
-* by write samples into sound buffer and by converting them from
-* 'signed' to 'unsigned' */
-for (i = 0; i < len; i++)
-{
-*pBuffer++ = MixBuffer[(CompleteSndBufIdx + i) % MIXBUFFER_SIZE][0];
-*pBuffer++ = MixBuffer[(CompleteSndBufIdx + i) % MIXBUFFER_SIZE][1];
-}
-CompleteSndBufIdx += len;
-nGeneratedSamples -= len;
-}
-else /* Not enough samples available: */
-{
-for (i = 0; i < nGeneratedSamples; i++)
-{
-*pBuffer++ = MixBuffer[(CompleteSndBufIdx + i) % MIXBUFFER_SIZE][0];
-*pBuffer++ = MixBuffer[(CompleteSndBufIdx + i) % MIXBUFFER_SIZE][1];
-}
-/* If the buffer is filled more than 50%, mirror sample buffer to fake the
-* missing samples */
-if (nGeneratedSamples >= len/2)
-{
-int remaining = len - nGeneratedSamples;
-memcpy(pBuffer, ((Uint8*)SNDBUF)+(nGeneratedSamples-remaining)*4, remaining*4);
-}
-CompleteSndBufIdx += nGeneratedSamples;
-nGeneratedSamples = 0;
-}
-CompleteSndBufIdx = CompleteSndBufIdx % MIXBUFFER_SIZE;
+	Sint16 *pBuffer;
+	int i, window, nSamplesPerFrame;
+
+	pBuffer = (Sint16 *)&SNDBUF[0];
+	len = len / 4; // Use length in samples (16 bit stereo), not in bytes
+
+	/* Adjust emulation rate within +/- 0.58% (10 cents) occasionally,
+	 * to synchronize sound. Note that an octave (frequency doubling)
+	 * has 12 semitones (12th root of two for a semitone), and that
+	 * one semitone has 100 cents (1200th root of two for one cent).
+	 * Ten cents are desired, thus, the 120th root of two minus one is
+	 * multiplied by 1,000,000 to convert to microseconds, and divided
+	 * by nScreenRefreshRate=60 to get a 96 microseconds swallow size.
+	 * (2^(10cents/(12semitones*100cents)) - 1) * 10^6 / nScreenRefreshRate
+	 * See: main.c - Main_WaitOnVbl()
+	 */
+
+	pulse_swallowing_count = 0; /* 0 = Unaltered emulation rate */
+
+	if (ConfigureParams.Sound.bEnableSoundSync)
+	{
+		/* Sound synchronized emulation */
+		nSamplesPerFrame = nAudioFrequency/nScreenRefreshRate;
+		window = (nSamplesPerFrame > SoundBufferSize) ? nSamplesPerFrame : SoundBufferSize;
+
+		/* Window Comparator for SoundBufferSize */
+		if (nGeneratedSamples < window + (window >> 1))
+		/* Increase emulation rate to maintain sound synchronization */
+			pulse_swallowing_count = -5793 / nScreenRefreshRate;
+		else
+		if (nGeneratedSamples > (window << 1) + (window >> 2))
+		/* Decrease emulation rate to maintain sound synchronization */
+			pulse_swallowing_count = 5793 / nScreenRefreshRate;
+
+		/* Otherwise emulation rate is unaltered. */
+	}
+	if (nGeneratedSamples >= len)
+	{
+		/* Enough samples available: Pass completed buffer to audio system
+		* by write samples into sound buffer and by converting them from
+		* 'signed' to 'unsigned' */
+		for (i = 0; i < len; i++)
+		{
+			*pBuffer++ = MixBuffer[(CompleteSndBufIdx + i) % MIXBUFFER_SIZE][0];
+			*pBuffer++ = MixBuffer[(CompleteSndBufIdx + i) % MIXBUFFER_SIZE][1];
+		}
+		CompleteSndBufIdx += len;
+		nGeneratedSamples -= len;
+	}
+	else /* Not enough samples available: */
+	{
+		for (i = 0; i < nGeneratedSamples; i++)
+		{
+			*pBuffer++ = MixBuffer[(CompleteSndBufIdx + i) % MIXBUFFER_SIZE][0];
+			*pBuffer++ = MixBuffer[(CompleteSndBufIdx + i) % MIXBUFFER_SIZE][1];
+		}
+		/* If the buffer is filled more than 50%, mirror sample buffer to fake the
+		* missing samples */
+		if (nGeneratedSamples >= len/2)
+		{
+			int remaining = len - nGeneratedSamples;
+			memcpy(pBuffer, ((Uint8*)SNDBUF)+(nGeneratedSamples-remaining)*4, remaining*4);
+		}
+		CompleteSndBufIdx += nGeneratedSamples;
+		nGeneratedSamples = 0;
+	}
+
+	CompleteSndBufIdx = CompleteSndBufIdx % MIXBUFFER_SIZE;
 }
 #endif
 

--- a/src/sound.c
+++ b/src/sound.c
@@ -1480,8 +1480,8 @@ static void Retro_Audio_CallBack(int len)
 	if (nGeneratedSamples >= len)
 	{
 		/* Enough samples available: Pass completed buffer to audio system
-		* by write samples into sound buffer and by converting them from
-		* 'signed' to 'unsigned' */
+		 * by write samples into sound buffer and by converting them from
+		 * 'signed' to 'unsigned' */
 		for (i = 0; i < len; i++)
 		{
 			*pBuffer++ = MixBuffer[(CompleteSndBufIdx + i) % MIXBUFFER_SIZE][0];
@@ -1497,13 +1497,10 @@ static void Retro_Audio_CallBack(int len)
 			*pBuffer++ = MixBuffer[(CompleteSndBufIdx + i) % MIXBUFFER_SIZE][0];
 			*pBuffer++ = MixBuffer[(CompleteSndBufIdx + i) % MIXBUFFER_SIZE][1];
 		}
-		/* If the buffer is filled more than 50%, mirror sample buffer to fake the
-		* missing samples */
-		if (nGeneratedSamples >= len/2)
-		{
-			int remaining = len - nGeneratedSamples;
-			memcpy(pBuffer, ((Uint8*)SNDBUF)+(nGeneratedSamples-remaining)*4, remaining*4);
-		}
+		/* Clear rest of the buffer to ensure we don't play random bytes instead */
+		/* of missing samples */
+		memset(pBuffer, 0, (len - nGeneratedSamples) * 4);
+
 		CompleteSndBufIdx += nGeneratedSamples;
 		nGeneratedSamples = 0;
 	}

--- a/src/sound.c
+++ b/src/sound.c
@@ -1496,7 +1496,7 @@ for (i = 0; i < nGeneratedSamples; i++)
 if (nGeneratedSamples >= len/2)
 {
 int remaining = len - nGeneratedSamples;
-memcpy(pBuffer, SNDBUF+(nGeneratedSamples-remaining)*4, remaining*4);
+memcpy(pBuffer, ((Uint8*)SNDBUF)+(nGeneratedSamples-remaining)*4, remaining*4);
 }
 CompleteSndBufIdx += nGeneratedSamples;
 nGeneratedSamples = 0;


### PR DESCRIPTION
This code seems to be copy pasted from audio.c Audio_Callback and modified. "SNDBUF" is not a Uint8* like the original "stream" so the remaining samples logic here was off by a factor of 2.

The second commit restores the original whitespace to the copied code to make it more readable.