### PR TITLE
fix the missing sample issue (was causing constant 30hz buzz/crackle)

### DIFF
--- a/src/sound.c
+++ b/src/sound.c
@@ -1533,10 +1533,16 @@ Retro_Audio_CallBack(CurrentSamplesNb*4);
 	CurrentSamplesNb = 0;					/* VBL is complete, reset counter for next VBL */
 
 	/*Compute a fractional equivalent of SamplesPerFrame for the next VBL, to avoid rounding propagation */
-	SamplesPerFrame_unrounded += (yms64) ClocksTimings_GetSamplesPerVBL ( ConfigureParams.System.nMachineType ,
-			nScreenRefreshRate , nAudioFrequency );
-	SamplesPerFrame = SamplesPerFrame_unrounded >> 28;		/* use integer part */
-	SamplesPerFrame_unrounded &= 0x0fffffff;			/* keep fractional part in the lower 28 bits */
+	//SamplesPerFrame_unrounded += (yms64) ClocksTimings_GetSamplesPerVBL ( ConfigureParams.System.nMachineType ,
+	//		nScreenRefreshRate , nAudioFrequency );
+	//SamplesPerFrame = SamplesPerFrame_unrounded >> 28;		/* use integer part */
+	//SamplesPerFrame_unrounded &= 0x0fffffff;			/* keep fractional part in the lower 28 bits */
+
+	// Hatari's audio system seems to be able to deal with a variable number of samples per frame, keeping aligned with the Atari's not-quite-50/60 Hz,
+	// but our RetroArch interface does not seem to be able to handle it (pads with 0 to fill the rest, creating a constant buzz).
+	// Forcing it to generate all samples every frame:
+	SamplesPerFrame = nAudioFrequency / nScreenRefreshRate;
+	SamplesPerFrame_unrounded = 0;
 
 	/* Reset sound buffer if needed (after pause, fast forward, slow system, ...) */
 	if ( Sound_BufferIndexNeedReset )


### PR DESCRIPTION
This addresses the last remaining error I reported in #48 .

Hatari was generating audio at a variable number of samples per frame, to stay synchronized with hardware accurate timings that aren't quite 50/60hz, but the way we're funnelling audio to RetroArch can't seem to deal with this, causing a 0 sample to appear at the end of frames periodically (creating an unpleasant buzz).

This change forces it to use the expected number of samples every frame rather than trying to make this minute accuracy adjustment. The change is similar to setting RoundVBLPerSec to true, but instead the effect is only limited to the audio output; other emulation should remain the same.