### PR TITLE
Better mouse interaction with Hatari GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ X   Hatari GUI
 
 Analog Left - Joystick / Mouse
 Mouse - Mouse
+~ key - Hatari GUI
 ```
 
 ## Knows Bugs

--- a/libretro/hatari-mapper.c
+++ b/libretro/hatari-mapper.c
@@ -392,7 +392,7 @@ void update_input(void)
    Process_key();
 
    i=RETRO_DEVICE_ID_JOYPAD_X;
-   if (Key_Sate[RETROK_F11] || input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) )
+   if (Key_Sate[RETROK_TILDE] || Key_Sate[RETROK_BACKQUOTE] || input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) )
       pauseg=1;
 
    i=RETRO_DEVICE_ID_JOYPAD_L;//show vkey toggle


### PR DESCRIPTION
Use "pointer" interface rather than relative mouse so that the host mouse doesn't slide off the window when using the Hatari GUI without a captured mouse.

When in the Hatari GUI both the mouse and gamepad can be used to operate at the same time, doesn't require switching via select button.

F11 key for Hatari GUI was in conflict with Retroarch F11 capture mouse key. Moved to ~