### PR TITLE
Two player support, other interface tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ X   Hatari GUI
 
 Analog Left - Joystick / Mouse
 Mouse - Mouse
+~ key - Hatari GUI
 ```
 
 ## Knows Bugs

--- a/README.md
+++ b/README.md
@@ -55,22 +55,36 @@ Note : zip support is provided by RetroArch and is done before passing the game 
 ## Default Controls
 
 ```
-L2  Show/Hide status
-R2  Select virtual keyboard page
-L   Show/hide virtual keyboard
-R   Change Mouse speed 1 to 6 . (for gui and emu)
-SEL Toggle Mouse/Joy mode
-STR Toggle joystick number
+Port 1:
+
 B   Fire / Left mouse button / Virtual keyboard keypress
 A   Auto-Fire / Right mouse button
-Y   Toggle Shift
+Y   Toggle virtual keyboard shift
 X   Hatari GUI
+SEL Toggle Joystick / Mouse mode
+STR Toggle 2 joysticks mode
+L   Show/hide virtual keyboard
+R   Change Mouse speed 1 to 6 . (for gui and emu)
+L2  Show/Hide status
+R2  Select virtual keyboard page
+Pad / Analog Left - Joystick / Mouse
 
-Analog Left - Joystick / Mouse
-Mouse - Mouse
-~ key - Hatari GUI
+Port 2:
+
+B   Fire
+A   Auto-Fire
+STR Toggle 2 joysticks mode
+L2  Show/Hide status
+Pad / Analog Left - Joystick
+
+Other:
+
+Mouse - Mouse (when port 1 is not in Joystick mode)
+Key ~/` - Hatari GUI
+Keyboard - Atari ST keys
+Scroll Lock - (RetroArch default hotkey) game focus mode disables keyboard shortcuts, captures mouse
+F11 - (RetroArch default hotkey) capture/release mouse
 ```
 
 ## Knows Bugs
-- HATARI GUI is not functionnal because of a mouse bug (too much speed). Usually you don't need to enter the GUI. It was fixed in the P-UAE core with the same GUI, so a patch will be done for this core.
-- It's a debug release, so expect bug.
+- It's a debug release, so expect bug?

--- a/libretro/cmdline.c
+++ b/libretro/cmdline.c
@@ -13,6 +13,7 @@ extern int  hmain(int argc, char *argv[]);
 void parse_cmdline( const char *argv );
 
 // Global variables
+extern bool hatari_fastfdc;
 extern bool hatari_borders;
 extern char hatari_frameskips[2];
 
@@ -49,6 +50,8 @@ int pre_main(const char *argv)
       Add_Option("hatari");
       Add_Option("--statusbar");
       Add_Option("0");
+      Add_Option("--fastfdc");
+      Add_Option(hatari_fastfdc==true?"1":"0");
       Add_Option("--borders");
       Add_Option(hatari_borders==true?"1":"0");
       Add_Option("--frameskips");

--- a/libretro/hatari-mapper.c
+++ b/libretro/hatari-mapper.c
@@ -392,7 +392,7 @@ void update_input(void)
    Process_key();
 
    i=RETRO_DEVICE_ID_JOYPAD_X;
-   if (Key_Sate[RETROK_F11] || input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) )
+   if (Key_Sate[RETROK_TILDE] || Key_Sate[RETROK_BACKQUOTE] || input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) )
       pauseg=1;
 
    i=RETRO_DEVICE_ID_JOYPAD_L;//show vkey toggle

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -72,15 +72,28 @@ static struct retro_input_descriptor input_descriptors[] = {
    { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "Right" },
    { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A, "Turbo Fire" },
    { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B, "Fire" },
-   { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X, "Enter GUI" },
-   { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y, "Shift toggle" },
-   { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "Mouse mode toggle" },
-   { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START, "Keyboard overlay" },
-   { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2, "Toggle status display" },
-   { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L, "Joystick number" },
+   { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X, "Hatari Settings" },
+   { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y, "Shift keyboard toggle" },
+   { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "Joystick/Mouse toggle" },
+   { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START, "Joystick 2 toggle" },
+   { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L, "Virtual keyboard" },
    { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R, "Mouse speed" },
+   { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2, "Status display" },
+   { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2, "Virtual keyboard page" },
+   { 0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Joystick/Mouse X" },
+   { 0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Joystick/Mouse Y" },
+   { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP, "Up" },
+   { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN, "Down" },
+   { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT, "Left" },
+   { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "Right" },
+   { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A, "Turbo Fire" },
+   { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B, "Fire" },
+   { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START, "Joystick 2 toggle" },
+   { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2, "Status display" },
+   { 1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Joystick X" },
+   { 1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Joystick Y" },
    // Terminate
-   { 255, 255, 255, 255, NULL }
+   { 0 }
 };
 
 void retro_set_environment(retro_environment_t cb)
@@ -462,27 +475,7 @@ void retro_init(void)
       exit(0);
    }
 
-	struct retro_input_descriptor inputDescriptors[] = {
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A, "A" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B, "B" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X, "X" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y, "Y" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "Select" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START, "Start" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "Right" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT, "Left" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP, "Up" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN, "Down" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R, "R" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L, "L" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2, "R2" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2, "L2" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3, "R3" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3, "L3" },
-		// Terminate
-		{ 0 }
-	};
-	environ_cb(RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, &inputDescriptors);
+	environ_cb(RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, input_descriptors);
 
    static struct retro_midi_interface midi_interface;
 
@@ -644,7 +637,7 @@ void retro_run(void)
 bool retro_load_game(const struct retro_game_info *info)
 {
    // Init
-   environ_cb(RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, input_descriptors);   
+   environ_cb(RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, input_descriptors);
    path_join(RETRO_TOS, RETRO_DIR, "tos.img");
    
    // Verify if tos.img is present

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -108,8 +108,8 @@ void retro_set_environment(retro_environment_t cb)
          "High resolution",
          "Needs restart",
          {
-            { "false", "disabled" },
             { "true", "enabled" },
+            { "false", "disabled" },
             { NULL, NULL },
          },
          "yes"

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -60,6 +60,7 @@ unsigned int video_config = 0;
 int CHANGE_RATE = 0, CHANGEAV_TIMING = 0;
 float FRAMERATE = 50.0, SAMPLERATE = 44100.0;
 
+bool hatari_fastfdc = true;
 bool hatari_borders = true;
 char hatari_frameskips[2];
 int firstpass = 1;
@@ -102,7 +103,19 @@ void retro_set_environment(retro_environment_t cb)
 
    static struct retro_core_option_definition core_options[] =
    {
-	   // Video
+       // Floppy speed
+       {
+         "hatari_fastfdc",
+         "Fast floppy access",
+         "Needs restart",
+         {
+           { "true", "enabled" },
+           { "false", "disabled" },
+           { NULL, NULL },
+         },
+         "true"
+       },
+       // Video
        {
          "hatari_video_hires",
          "High resolution",
@@ -112,7 +125,7 @@ void retro_set_environment(retro_environment_t cb)
             { "false", "disabled" },
             { NULL, NULL },
          },
-         "yes"
+         "true"
       },
       {
          "hatari_video_crop_overscan",
@@ -183,6 +196,17 @@ void retro_set_environment(retro_environment_t cb)
 static void update_variables(void)
 {
    struct retro_variable var = {0};
+
+   // Floppy
+   var.key = "hatari_fastfdc";
+   var.value = NULL;
+   hatari_fastfdc = false;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if(strcmp(var.value, "true") == 0)
+         hatari_fastfdc = true;
+   }
 
    // Video
    var.key = "hatari_video_hires";

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -108,8 +108,8 @@ void retro_set_environment(retro_environment_t cb)
          "High resolution",
          "Needs restart",
          {
-            { "true", "enabled" },
             { "false", "disabled" },
+            { "true", "enabled" },
             { NULL, NULL },
          },
          "yes"
@@ -187,6 +187,7 @@ static void update_variables(void)
    // Video
    var.key = "hatari_video_hires";
    var.value = NULL;
+   video_config = 0;
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
@@ -297,6 +298,7 @@ void retro_shutdown_hatari(void)
 }
 
 void retro_reset(void){
+   update_variables();
    Reset_Warm();
 }
 

--- a/src/ikbd.c
+++ b/src/ikbd.c
@@ -1383,8 +1383,8 @@ static void IKBD_SendRelMousePacket(void)
 }
 
 #ifdef __LIBRETRO__
-//FIXME ADD MXjoy1
 extern unsigned char MXjoy0;
+extern unsigned char MXjoy1;
 extern int NUMjoy;
 #endif
 
@@ -1409,7 +1409,7 @@ if(NUMjoy<0){
 	        || (bBothMouseAndJoy && KeyboardProcessor.MouseMode==AUTOMODE_MOUSEREL))
 		KeyboardProcessor.Joy.JoyData[0] = 
 #ifdef __LIBRETRO__
-			MXjoy0;
+			MXjoy1;
 #else
 			Joy_GetStickData(0);
 #endif


### PR DESCRIPTION
- Makes pressing start for 2 joystick mode functional, second gamepad works.
- Documenting controls in README.md and in retro_input_descriptor
- Mouse speed now affect analog stick mouse control as well
- Analog stick can now control the virtual keyboard
- Moved status bar 24px lower to be in the overscan area out of the way
- Faster load times with fast floppy option

Extends #62 so either pull that first or close it and pull this instead:
- Use "pointer" interface rather than relative mouse so that the host mouse doesn't slide off the window when using the Hatari GUI without a captured mouse
- When in the Hatari GUI both the mouse and gamepad can be used to operate at the same time, doesn't require switching via select button
- F11 key for Hatari GUI was in conflict with Retroarch F11 capture mouse key. Moved to ~