### PR TITLE
Audio distortion fix

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -60,6 +60,7 @@ unsigned int video_config = 0;
 int CHANGE_RATE = 0, CHANGEAV_TIMING = 0;
 float FRAMERATE = 50.0, SAMPLERATE = 44100.0;
 
+extern bool UseNonPolarizedLowPassFilter;
 bool hatari_fastfdc = true;
 bool hatari_borders = true;
 char hatari_frameskips[2];
@@ -114,6 +115,18 @@ void retro_set_environment(retro_environment_t cb)
            { NULL, NULL },
          },
          "true"
+       },
+       // Audio
+       {
+         "hatari_polarized_filter",
+         "Polarized audio filter",
+         "Uses hatari's polarized lowpass filters on audio to simulate distortion",
+         {
+           { "false", "disabled" },
+           { "true", "enabled" },
+           { NULL, NULL },
+         },
+         "false"
        },
        // Video
        {
@@ -210,6 +223,16 @@ static void update_variables(void)
    {
       hatari_fastfdc = new_hatari_fastfdc;
       ConfigureParams.DiskImage.FastFloppy = hatari_fastfdc;
+   }
+
+   // Audio
+   var.key = "hatari_polarized_filter";
+   var.value = NULL;
+   UseNonPolarizedLowPassFilter = true;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if(strcmp(var.value, "true") == 0)
+         UseNonPolarizedLowPassFilter = false;
    }
 
    // Video


### PR DESCRIPTION
After f8c35958ec1c93c32d41d61fa4903b2f5daec78c and #59 fixed the most glaring issue with audio generation, finally delivering uninterrupted audio from Hatari, I've been able to look more carefully to the audio being generated.

I found that we were getting a large amount of distortion from Hatari's sound generation. This is due to a strange polarized lowpass filter implementation in Hatari itself, which shapes the waveform differently on a rising than falling edge.

So: I've created a more traditional implementation of a lowpass filter to substitute, and created an option to switch back to the distorting filters for anyone that prefers it.

The current version of Hatari does not sound as distorted, but the underlying polarized filter operation seems to be the same. I think in a later version they may have increased the resolution that the audio is simulated at before applying the filter, pushing most of its distortion effects out of the audible range by accident, hiding the problem? Given how different the generated sound is from real Atari ST recordings I've compared against, I'm not sure that code in Hatari works quite as it was intended.

...but at any rate, whether or not that's a bug in Hatari is a separate issue. I added an alternative as an option, on by default, and I think it sounds a lot nicer (i.e. cleaner, clearer). The relevant code changes are quite small and have no new performance implications.