### PR TITLE
Upstream joystick handling, fixes some broken games

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ A   Auto-Fire / Right mouse button
 Y   Toggle virtual keyboard Shift
 X   Show/hide virtual keyboard
 SEL Toggle Joystick / Mouse mode
-STR Hatari GUI
+STR Enter/Exit Hatari GUI
 L   Show/Hide status
 R   Select virtual keyboard page
 L2  Lower Mouse Speed (1-6) for gui and emu

--- a/README.md
+++ b/README.md
@@ -59,21 +59,20 @@ Port 1:
 
 B   Fire / Left mouse button / Virtual keyboard keypress
 A   Auto-Fire / Right mouse button
-Y   Toggle virtual keyboard shift
-X   Hatari GUI
+Y   Toggle virtual keyboard Shift
+X   Show/hide virtual keyboard
 SEL Toggle Joystick / Mouse mode
-STR Toggle 2 joysticks mode
-L   Show/hide virtual keyboard
-R   Change Mouse speed 1 to 6 . (for gui and emu)
-L2  Show/Hide status
-R2  Select virtual keyboard page
+STR Hatari GUI
+L   Show/Hide status
+R   Select virtual keyboard page
+L2  Lower Mouse Speed (1-6) for gui and emu
+R2  Raise Mouse speed (1-6)
 Pad / Analog Left - Joystick / Mouse
 
 Port 2:
 
 B   Fire
 A   Auto-Fire
-STR Toggle 2 joysticks mode
 L2  Show/Hide status
 Pad / Analog Left - Joystick
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ Pad / Analog Left - Joystick
 Other:
 
 Mouse - Mouse (when port 1 is not in Joystick mode)
-Key ~/` - Hatari GUI
 Keyboard - Atari ST keys
 Scroll Lock - (RetroArch default hotkey) game focus mode disables keyboard shortcuts, captures mouse
 F11 - (RetroArch default hotkey) capture/release mouse

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ L   Show/Hide status
 R   Select virtual keyboard page
 L2  Lower Mouse Speed (1-6) for gui and emu
 R2  Raise Mouse speed (1-6)
+R3  Keyboard space
 Pad / Analog Left - Joystick / Mouse
 
 Port 2:

--- a/libretro/cmdline.c
+++ b/libretro/cmdline.c
@@ -13,6 +13,7 @@ extern int  hmain(int argc, char *argv[]);
 void parse_cmdline( const char *argv );
 
 // Global variables
+extern bool hatari_twojoy;
 extern bool hatari_fastfdc;
 extern bool hatari_borders;
 extern char hatari_frameskips[2];
@@ -50,6 +51,8 @@ int pre_main(const char *argv)
       Add_Option("hatari");
       Add_Option("--statusbar");
       Add_Option("0");
+      Add_Option("--joy0");
+      Add_Option(hatari_twojoy==true?"real":"none");
       Add_Option("--fastfdc");
       Add_Option(hatari_fastfdc==true?"1":"0");
       Add_Option("--borders");

--- a/libretro/gui-retro/dlgAbout.c
+++ b/libretro/gui-retro/dlgAbout.c
@@ -54,13 +54,12 @@ void Dialog_AboutDlg(void)
 	aboutdlg[1].x = (aboutdlg[0].w - strlen(PROG_NAME)) / 2;
 
 	SDLGui_CenterDlg(aboutdlg);
-        do
+	do
 	{
-                but=SDLGui_DoDialog(aboutdlg, NULL);
-                gui_poll_events();
-
-        }
-        while (but != DLGABOUT_EXIT && but != SDLGUI_QUIT
+		but=SDLGui_DoDialog(aboutdlg, NULL);
+		if (gui_poll_events()) break;
+	}
+	while (but != DLGABOUT_EXIT && but != SDLGUI_QUIT
 	       && but != SDLGUI_ERROR && !bQuitProgram);
 
 }

--- a/libretro/gui-retro/dlgAlert.c
+++ b/libretro/gui-retro/dlgAlert.c
@@ -171,11 +171,10 @@ static int DlgAlert_ShowDlg(const char *text)
 	bOldMouseVisibility = SDL_ShowCursor(SDL_QUERY);
 	SDL_ShowCursor(SDL_ENABLE);
 
-        do
-	{                     
-	       i = SDLGui_DoDialog(alertdlg, NULL);
-               gui_poll_events();
-
+	do
+	{
+		i = SDLGui_DoDialog(alertdlg, NULL);
+		if (gui_poll_events()) break;
 	}
 	while (i != DLGALERT_OK && i != DLGALERT_CANCEL && i != SDLGUI_QUIT
 	        && i != SDLGUI_ERROR && !bQuitProgram);

--- a/libretro/gui-retro/dlgDevice.c
+++ b/libretro/gui-retro/dlgDevice.c
@@ -145,7 +145,7 @@ void Dialog_DeviceDlg(void)
                                               true);
 			break;
 		}
-		gui_poll_events();
+		if (gui_poll_events()) break;
 	}
 	while (but != DEVDLG_EXIT && but != SDLGUI_QUIT
 	       && but != SDLGUI_ERROR && !bQuitProgram);

--- a/libretro/gui-retro/dlgFileSelect.c
+++ b/libretro/gui-retro/dlgFileSelect.c
@@ -833,7 +833,7 @@ char* SDLGui_FileSelect(const char *title,const char *path_and_name, char **zip_
 				scrollbar_Ypos = 0.0;
 			}
 		} /* other button code */
-                gui_poll_events();
+		if (gui_poll_events()) retbut=SGFSDLG_CANCEL;
 
 	} /* do */
 	while (retbut!=SGFSDLG_OKAY && retbut!=SGFSDLG_CANCEL

--- a/libretro/gui-retro/dlgFloppy.c
+++ b/libretro/gui-retro/dlgFloppy.c
@@ -289,7 +289,7 @@ void DlgFloppy_Main(void)
 			}
 			break;
 		}
-                gui_poll_events();
+		if (gui_poll_events()) break;
 	}
 	while (but != FLOPPYDLG_EXIT && but != SDLGUI_QUIT
 	        && but != SDLGUI_ERROR && !bQuitProgram);

--- a/libretro/gui-retro/dlgHardDisk.c
+++ b/libretro/gui-retro/dlgHardDisk.c
@@ -211,7 +211,7 @@ printf("skip: %d\n", ConfigureParams.HardDisk.nHardDiskDrive);
 				ConfigureParams.HardDisk.bUseHardDiskDirectories = true;
 			break;
 		}
-                gui_poll_events();
+		if (gui_poll_events()) break;
 	}
 	while (but != DISKDLG_EXIT && but != SDLGUI_QUIT
 	        && but != SDLGUI_ERROR && !bQuitProgram);

--- a/libretro/gui-retro/dlgJoystick.c
+++ b/libretro/gui-retro/dlgJoystick.c
@@ -260,7 +260,7 @@ void Dialog_JoyDlg(void)
 			}
 			break;
 		}
-                gui_poll_events();
+		if (gui_poll_events()) break;
 	}
 	while (but != DLGJOY_EXIT && but != SDLGUI_QUIT
 	       && but != SDLGUI_ERROR && !bQuitProgram);

--- a/libretro/gui-retro/dlgKeyboard.c
+++ b/libretro/gui-retro/dlgKeyboard.c
@@ -82,7 +82,7 @@ void Dialog_KeyboardDlg(void)
 			                      ConfigureParams.Keyboard.szMappingFileName,
 			                      keyboarddlg[DLGKEY_MAPNAME].w, false);
 		}
-                gui_poll_events();
+		if (gui_poll_events()) break;
 	}
 	while (but != DLGKEY_EXIT && but != SDLGUI_QUIT
 	        && but != SDLGUI_ERROR && !bQuitProgram);

--- a/libretro/gui-retro/dlgMain.c
+++ b/libretro/gui-retro/dlgMain.c
@@ -160,8 +160,7 @@ int Dialog_MainDlg(bool *bReset, bool *bLoadedSnapshot)
 			bQuitProgram = true;
 			break;
 		}
-                gui_poll_events();
-
+		if (gui_poll_events()) retbut = MAINDLG_CANCEL;
 	}
 	while (retbut != MAINDLG_OK && retbut != MAINDLG_CANCEL && retbut != SDLGUI_QUIT
 	        && retbut != SDLGUI_ERROR && !bQuitProgram);

--- a/libretro/gui-retro/dlgMemory.c
+++ b/libretro/gui-retro/dlgMemory.c
@@ -130,7 +130,7 @@ bool Dialog_MemDlg(void)
 			}
 			break;
 		}
-                gui_poll_events();
+		if (gui_poll_events()) break;
 	}
 	while (but != DLGMEM_EXIT && but != SDLGUI_QUIT
 	        && but != SDLGUI_ERROR && !bQuitProgram );

--- a/libretro/gui-retro/dlgNewDisk.c
+++ b/libretro/gui-retro/dlgNewDisk.c
@@ -146,7 +146,7 @@ char *DlgNewDisk_Main(void)
 			}
 			break;
 		}
-                gui_poll_events();
+		if (gui_poll_events()) break;
 	}
 	while (but != DLGNEWDISK_EXIT && but != SDLGUI_QUIT
 	       && but != SDLGUI_ERROR && !bQuitProgram);

--- a/libretro/gui-retro/dlgRom.c
+++ b/libretro/gui-retro/dlgRom.c
@@ -87,7 +87,7 @@ void DlgRom_Main(void)
 					      false);
 			break;
 		}
-                gui_poll_events();
+		if (gui_poll_events()) break;
 	}
 	while (but != DLGROM_EXIT && but != SDLGUI_QUIT
 	       && but != SDLGUI_ERROR && !bQuitProgram);

--- a/libretro/gui-retro/dlgScreen.c
+++ b/libretro/gui-retro/dlgScreen.c
@@ -265,7 +265,7 @@ void Dialog_MonitorDlg(void)
 			sprintf(sVdiHeight, "%4i", ConfigureParams.Screen.nVdiHeight);
 			break;
 		}
-                gui_poll_events();
+		if (gui_poll_events()) break;
 	}
 	while (but != DLGSCRN_EXIT_MONITOR && but != SDLGUI_QUIT
 	        && but != SDLGUI_ERROR && !bQuitProgram);
@@ -411,7 +411,7 @@ void Dialog_WindowDlg(void)
 			}
 			break;
 		}
-                gui_poll_events();
+		if (gui_poll_events()) break;
 	}
 	while (but != DLGSCRN_EXIT_WINDOW && but != SDLGUI_QUIT
 	        && but != SDLGUI_ERROR && !bQuitProgram);

--- a/libretro/gui-retro/dlgSound.c
+++ b/libretro/gui-retro/dlgSound.c
@@ -171,7 +171,7 @@ void Dialog_SoundDlg(void)
 			}
 			break;
 		}
-                gui_poll_events();
+		if (gui_poll_events()) break;
 	}
 	while (but != DLGSOUND_EXIT && but != SDLGUI_QUIT
 	        && but != SDLGUI_ERROR && !bQuitProgram );

--- a/libretro/gui-retro/dlgSystem.c
+++ b/libretro/gui-retro/dlgSystem.c
@@ -257,13 +257,12 @@ void Dialog_SystemDlg(void)
 int but;
 do
 {
-       
 	/* Show the dialog: */
 	but=SDLGui_DoDialog(systemdlg, NULL);
-        gui_poll_events();
+	if (gui_poll_events()) break;
 }
 while (but != DLGSYS_EXIT && but != SDLGUI_QUIT
-	       && but != SDLGUI_ERROR && !bQuitProgram);
+       && but != SDLGUI_ERROR && !bQuitProgram);
 
 	/* Read values from dialog: */
 

--- a/libretro/hatari-mapper.c
+++ b/libretro/hatari-mapper.c
@@ -466,7 +466,7 @@ void update_input(void)
    Process_key();
 
    i=RETRO_DEVICE_ID_JOYPAD_START;// Hatari GUI
-   if (Key_Sate[RETROK_TILDE] || Key_Sate[RETROK_BACKQUOTE] || input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) )
+   if ( input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) )
    {
       pauseg=1;
    }

--- a/libretro/hatari-mapper.c
+++ b/libretro/hatari-mapper.c
@@ -5,6 +5,7 @@
 #include "joy.h"
 #include "screen.h"
 #include "video.h"	/* FIXME: video.h is dependent on HBL_PALETTE_LINES from screen.h */
+#include "ikbd.h"
 
 //CORE VAR
 extern const char *retro_save_directory;
@@ -82,6 +83,20 @@ extern int LEDA,LEDB,LEDC;
 int BOXDEC= 32+2;
 int STAT_BASEY;
 
+// deactivate mouse when using 2 joyticks
+
+void update_numjoy()
+{
+	if (NUMjoy < 0)
+	{
+		KeyboardProcessor.MouseMode = AUTOMODE_OFF;
+	}
+	else
+	{
+		KeyboardProcessor.MouseMode = AUTOMODE_MOUSEREL;
+	}
+}
+
 // savestate serialization
 
 static bool serialize_forward;
@@ -155,6 +170,7 @@ bool hatari_mapper_unserialize(const char* data, char version)
 	int pauseg_old = pauseg;
 	bool result = hatari_mapper_serialize_bidi((char*)data, version);
 	if (pauseg_old) pauseg = pauseg_old; // because of the co-thread implementation there's really no way to save-state out of the GUI, so: stay paused
+	update_numjoy();
 	return result;
 }
 
@@ -479,6 +495,7 @@ void update_input(void)
       mbt[i]=0;
       MOUSEMODE=-MOUSEMODE;
       if (MOUSEMODE > 0) NUMjoy=1;
+      update_numjoy();
    }
 
    i=RETRO_DEVICE_ID_JOYPAD_START;//num joy toggle (on either joystick)
@@ -489,6 +506,7 @@ void update_input(void)
       mbt[i]=0;
       NUMjoy=-NUMjoy;
       if (NUMjoy < 0) MOUSEMODE=-1;
+      update_numjoy();
    }
 
    i=RETRO_DEVICE_ID_JOYPAD_R;//mouse gui speed
@@ -653,6 +671,7 @@ void update_input(void)
             NUMjoy=-NUMjoy;
             if (NUMjoy < 0) MOUSEMODE = -1;
             oldi=-1;
+            update_numjoy();
          }
          else
          {

--- a/libretro/hatari-mapper.c
+++ b/libretro/hatari-mapper.c
@@ -384,6 +384,12 @@ void Process_key(void)
    {
       Key_Sate[i]=input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0,i) ? 0x80: 0;
 
+      if (i == RETROK_SPACE) // can map R3 to space bar
+      {
+         char joyspace = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3) ? 0x80 : 0;
+         Key_Sate[i] |= joyspace;
+      }
+
       if(SDLKeyToSTScanCode[i]==0x2a )
       {  //SHIFT CASE
 
@@ -434,6 +440,7 @@ void Deadzone(int* a)
    A   mouse-right
    Y   switch Shift ON/OFF
    X   show/hide vkbd
+   R3  keyboard space
    */
 
 void update_input(void)
@@ -785,6 +792,7 @@ void input_gui(void)
 {
    input_poll_cb();
 
+   int i;
    int mouse_l;
    int mouse_r;
    int16_t mouse_x,mouse_y;
@@ -794,7 +802,7 @@ void input_gui(void)
 
    // ability to adjust mouse speed in hatari GUI
 
-   int i=RETRO_DEVICE_ID_JOYPAD_L2;
+   i=RETRO_DEVICE_ID_JOYPAD_L2;
    if ( input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) && mbt[i]==0 )
       mbt[i]=1;
    else if ( mbt[i]==1 && ! input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) )
@@ -803,7 +811,7 @@ void input_gui(void)
       PAS--;if(PAS<0)PAS=MAXPAS;
    }
 
-   int i=RETRO_DEVICE_ID_JOYPAD_R2;
+   i=RETRO_DEVICE_ID_JOYPAD_R2;
    if ( input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) && mbt[i]==0 )
       mbt[i]=1;
    else if ( mbt[i]==1 && ! input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) )

--- a/libretro/hatari-mapper.c
+++ b/libretro/hatari-mapper.c
@@ -13,6 +13,7 @@ extern const char *retro_system_directory;
 extern const char *retro_content_directory;
 char RETRO_DIR[512];
 char RETRO_TOS[512];
+extern bool hatari_nomouse;
 
 //HATARI PROTOTYPES
 #include "configuration.h"
@@ -49,7 +50,7 @@ char RPATH[512];
 
 //EMU FLAGS
 int NPAGE=-1, KCOL=1, BKGCOLOR=0, MAXPAS=6;
-int SHIFTON=-1,MOUSEMODE=-1,SHOWKEY=-1,PAS=4,STATUTON=-1;
+int SHIFTON=-1,MOUSEMODE=-1,SHOWKEY=-1,PAS=2,STATUTON=-1;
 int SND=1; //SOUND ON/OFF
 int pauseg=0; //enter_gui
 int slowdown=0;
@@ -723,13 +724,20 @@ void update_input(void)
             MXjoy0 &= ~ATARIJOY_BITMASK_FIRE;
       }
 
-      mouse_x = input_state_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X);
-      mouse_y = input_state_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_Y);
-      mouse_l    = input_state_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_LEFT);
-      mouse_r    = input_state_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_RIGHT);
-
-      fmousex=mouse_x;
-      fmousey=mouse_y;
+      if (hatari_nomouse)
+      {
+         mouse_l = 0;
+         mouse_r = 0;
+      }
+      else
+      {
+         mouse_x = input_state_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X);
+         mouse_y = input_state_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_Y);
+         mouse_l = input_state_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_LEFT);
+         mouse_r = input_state_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_RIGHT);
+         fmousex=mouse_x;
+         fmousey=mouse_y;
+      }
 
    }
    else // MOUSEMODE >= 0

--- a/libretro/hatari-mapper.c
+++ b/libretro/hatari-mapper.c
@@ -756,13 +756,13 @@ void update_input(void)
 
       //emulate mouse with dpad
       if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT))
-         fmousex += PAS;
+         fmousex += PAS*3;
       if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT))
-         fmousex -= PAS;
+         fmousex -= PAS*3;
       if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN))
-         fmousey += PAS;
+         fmousey += PAS*3;
       if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP))
-         fmousey -= PAS;
+         fmousey -= PAS*3;
 
       mouse_l=input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B);
       mouse_r=input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A);
@@ -849,13 +849,13 @@ void input_gui(void)
    mouse_y += al[1]/1024;
 
    if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT))
-      mouse_x += PAS;
+      mouse_x += PAS*3;
    if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT))
-      mouse_x -= PAS;
+      mouse_x -= PAS*3;
    if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN))
-      mouse_y += PAS;
+      mouse_y += PAS*3;
    if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP))
-      mouse_y -= PAS;
+      mouse_y -= PAS*3;
    mouse_l=input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B);
    mouse_r=input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A);
 

--- a/libretro/hatari-mapper.c
+++ b/libretro/hatari-mapper.c
@@ -14,6 +14,7 @@ extern const char *retro_content_directory;
 char RETRO_DIR[512];
 char RETRO_TOS[512];
 extern bool hatari_nomouse;
+extern bool hatari_nokeys;
 
 //HATARI PROTOTYPES
 #include "configuration.h"
@@ -380,7 +381,7 @@ void Process_key(void)
    int i;
    for(i=0;i<320;i++)
    {
-      Key_Sate[i]=input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0,i) ? 0x80: 0;
+      Key_Sate[i]= (input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0,i) && !hatari_nokeys) ? 0x80: 0;
 
       if (i == RETROK_SPACE) // can map R3 to space bar
       {

--- a/libretro/include/gui-retro.h
+++ b/libretro/include/gui-retro.h
@@ -18,7 +18,7 @@
 
 #include "graph.h"
 
-extern void gui_poll_events();
+extern bool gui_poll_events();
 extern int  GuiGetMouseState( int * x,int * y);
 extern int pauseg;
 

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -62,6 +62,7 @@ float FRAMERATE = 50.0, SAMPLERATE = 44100.0;
 
 extern bool UseNonPolarizedLowPassFilter;
 bool hatari_twojoy = true;
+bool hatari_nomouse = false;
 bool hatari_fastfdc = true;
 bool hatari_borders = true;
 char hatari_frameskips[2];
@@ -104,7 +105,7 @@ void retro_set_environment(retro_environment_t cb)
 
    static struct retro_core_option_definition core_options[] =
    {
-       // Second joystick
+       // Input
        {
          "hatari_twojoy",
          "Enable second joystick",
@@ -115,6 +116,17 @@ void retro_set_environment(retro_environment_t cb)
            { NULL, NULL },
          },
          "true"
+       },
+       {
+         "hatari_nomouse",
+         "Disable mouse",
+         "Disables input from your sytem mouse device. Gamepad mouse mode (select) is not disabled.",
+         {
+           { "false", "disabled" },
+           { "true", "enabled" },
+           { NULL, NULL },
+         },
+         "false"
        },
        // Floppy speed
        {
@@ -221,7 +233,8 @@ static void update_variables(void)
 {
    struct retro_variable var = {0};
 
-   // Joystick
+   // Input
+
    var.key = "hatari_twojoy";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
@@ -230,6 +243,18 @@ static void update_variables(void)
       if(strcmp(var.value, "false") == 0)
          hatari_twojoy = false;
       ConfigureParams.Joysticks.Joy[0].nJoystickMode = hatari_twojoy ? JOYSTICK_REALSTICK : JOYSTICK_DISABLED;
+   }
+
+   var.key = "hatari_nomouse";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      hatari_nomouse = false;
+      if(strcmp(var.value, "true") == 0)
+         hatari_nomouse = true;
+      // This doesn't correspond to any Hatari configuration setting, as far as I could find,
+      // but instead just disables input from the RetroArch mouse device for the user (outside the Hatari GUI),
+      // to prevent conflicts if needed, because Hatari seems to automatically merge/combine mouse and joystick in a weird way.
    }
 
    // Floppy

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -82,6 +82,7 @@ static struct retro_input_descriptor input_descriptors[] = {
    { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R, "Mouse speed up" },
    { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2, "Status display" },
    { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2, "Virtual keyboard page" },
+   { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3, "Keyboard space" },
    { 0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Joystick/Mouse X" },
    { 0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Joystick/Mouse Y" },
    { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP, "Up" },

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -61,6 +61,7 @@ int CHANGE_RATE = 0, CHANGEAV_TIMING = 0;
 float FRAMERATE = 50.0, SAMPLERATE = 44100.0;
 
 extern bool UseNonPolarizedLowPassFilter;
+bool hatari_twojoy = true;
 bool hatari_fastfdc = true;
 bool hatari_borders = true;
 char hatari_frameskips[2];
@@ -73,12 +74,12 @@ static struct retro_input_descriptor input_descriptors[] = {
    { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "Right" },
    { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A, "Turbo Fire" },
    { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B, "Fire" },
-   { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X, "Hatari Settings" },
+   { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X, "Virtual keyboard" },
    { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y, "Shift keyboard toggle" },
    { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "Joystick/Mouse toggle" },
-   { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START, "Joystick 2 toggle" },
-   { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L, "Virtual keyboard" },
-   { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R, "Mouse speed" },
+   { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START, "Hatari Settings" },
+   { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L, "Mouse speed down" },
+   { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R, "Mouse speed up" },
    { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2, "Status display" },
    { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2, "Virtual keyboard page" },
    { 0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Joystick/Mouse X" },
@@ -89,7 +90,6 @@ static struct retro_input_descriptor input_descriptors[] = {
    { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "Right" },
    { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A, "Turbo Fire" },
    { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B, "Fire" },
-   { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START, "Joystick 2 toggle" },
    { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2, "Status display" },
    { 1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Joystick X" },
    { 1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Joystick Y" },
@@ -103,6 +103,18 @@ void retro_set_environment(retro_environment_t cb)
 
    static struct retro_core_option_definition core_options[] =
    {
+       // Second joystick
+       {
+         "hatari_twojoy",
+         "Enable second joystick",
+         "Enables a second joystick on port 2, may conflict with mouse.",
+         {
+           { "true", "enabled" },
+           { "false", "disabled" },
+           { NULL, NULL },
+         },
+         "true"
+       },
        // Floppy speed
        {
          "hatari_fastfdc",
@@ -207,6 +219,17 @@ void retro_set_environment(retro_environment_t cb)
 static void update_variables(void)
 {
    struct retro_variable var = {0};
+
+   // Joystick
+   var.key = "hatari_twojoy";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      hatari_twojoy = true;
+      if(strcmp(var.value, "false") == 0)
+         hatari_twojoy = false;
+      ConfigureParams.Joysticks.Joy[0].nJoystickMode = hatari_twojoy ? JOYSTICK_REALSTICK : JOYSTICK_DISABLED;
+   }
 
    // Floppy
    var.key = "hatari_fastfdc";

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -63,6 +63,7 @@ float FRAMERATE = 50.0, SAMPLERATE = 44100.0;
 extern bool UseNonPolarizedLowPassFilter;
 bool hatari_twojoy = true;
 bool hatari_nomouse = false;
+bool hatari_nokeys = false;
 bool hatari_fastfdc = true;
 bool hatari_borders = true;
 char hatari_frameskips[2];
@@ -120,7 +121,18 @@ void retro_set_environment(retro_environment_t cb)
        {
          "hatari_nomouse",
          "Disable mouse",
-         "Disables input from your sytem mouse device. Gamepad mouse mode (select) is not disabled.",
+         "Prevents input from your sytem mouse device. Gamepad mouse mode (select) is not disabled.",
+         {
+           { "false", "disabled" },
+           { "true", "enabled" },
+           { NULL, NULL },
+         },
+         "false"
+       },
+       {
+         "hatari_nokeys",
+         "Disable keyboard",
+         "Prevents input from your sytem keyboard. Virtual keyboard is not disabled.",
          {
            { "false", "disabled" },
            { "true", "enabled" },
@@ -255,6 +267,15 @@ static void update_variables(void)
       // This doesn't correspond to any Hatari configuration setting, as far as I could find,
       // but instead just disables input from the RetroArch mouse device for the user (outside the Hatari GUI),
       // to prevent conflicts if needed, because Hatari seems to automatically merge/combine mouse and joystick in a weird way.
+   }
+
+   var.key = "hatari_nokeys";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      hatari_nokeys = false;
+      if(strcmp(var.value, "true") == 0)
+         hatari_nokeys = true;
    }
 
    // Floppy

--- a/libretro/retromain.inc
+++ b/libretro/retromain.inc
@@ -19,7 +19,7 @@ extern char RETRO_DIR[512];
 extern char RETRO_TOS[512];
 extern char RPATH[512];
 extern long GetTicks(void);
-extern void pause_select();
+extern void enter_gui();
 extern int LoadTosFromRetroSystemDir();
 extern void retro_shutdown_hatari(void);
 

--- a/libretro/vkbd_def.h
+++ b/libretro/vkbd_def.h
@@ -114,7 +114,7 @@ Mvk MVk[NPLGN*NLIGN*2]={
 	{ " 5" ," 5"  ,76},
 	{ " 6" ,"Rgt" ,77},
 	{ " 1" ,"End" ,79},
-	{ "Njoy","Njoy",-5},
+	{ "Stat","Stat",-5},
 	{ "Col" ,"Col",-3},
 	{ "Ent" ,"Ent",28},
 	{ "Kbd" ,"Kbd",-4},

--- a/src/ikbd.c
+++ b/src/ikbd.c
@@ -1382,11 +1382,6 @@ static void IKBD_SendRelMousePacket(void)
 	}
 }
 
-#ifdef __LIBRETRO__
-extern unsigned char MXjoy0;
-extern unsigned char MXjoy1;
-extern int NUMjoy;
-#endif
 
 /**
  * Get joystick data
@@ -1394,31 +1389,14 @@ extern int NUMjoy;
 static void IKBD_GetJoystickData(void)
 {
 	/* Joystick 1 */
-	KeyboardProcessor.Joy.JoyData[1] = 
-#ifdef __LIBRETRO__
-			MXjoy0;
-#else
-			Joy_GetStickData(1);
-#endif
+	KeyboardProcessor.Joy.JoyData[1] = Joy_GetStickData(1);
 
-#ifdef __LIBRETRO__
-if(NUMjoy<0){
-#endif
 	/* If mouse is on, joystick 0 is not connected */
 	if (KeyboardProcessor.MouseMode==AUTOMODE_OFF
 	        || (bBothMouseAndJoy && KeyboardProcessor.MouseMode==AUTOMODE_MOUSEREL))
-		KeyboardProcessor.Joy.JoyData[0] = 
-#ifdef __LIBRETRO__
-			MXjoy1;
-#else
-			Joy_GetStickData(0);
-#endif
+		KeyboardProcessor.Joy.JoyData[0] = Joy_GetStickData(0);
 	else
 		KeyboardProcessor.Joy.JoyData[0] = 0x00;
-
-#ifdef __LIBRETRO__
-	}
-#endif
 }
 
 

--- a/src/joy.c
+++ b/src/joy.c
@@ -181,6 +181,12 @@ static bool Joy_ReadJoystick(int nSdlJoyID, JOYREADING *pJoyReading)
 }
 
 
+#ifdef __LIBRETRO__
+extern unsigned char MXjoy0;
+extern unsigned char MXjoy1;
+extern int NUMjoy;
+#endif
+
 /*-----------------------------------------------------------------------*/
 /**
  * Read PC joystick and return ST format byte, i.e. lower 4 bits direction
@@ -190,6 +196,11 @@ static bool Joy_ReadJoystick(int nSdlJoyID, JOYREADING *pJoyReading)
  */
 Uint8 Joy_GetStickData(int nStJoyId)
 {
+#ifdef __LIBRETRO__
+	if (nStJoyId == 1) return MXjoy0;
+	if (nStJoyId == 0) return MXjoy1;
+	return 0;
+#else
 	Uint8 nData = 0;
 	JOYREADING JoyReading;
 	int nSdlJoyId;
@@ -274,6 +285,7 @@ Uint8 Joy_GetStickData(int nStJoyId)
 	}
 
 	return nData;
+#endif
 }
 
 

--- a/src/joy.c
+++ b/src/joy.c
@@ -196,18 +196,15 @@ extern int NUMjoy;
  */
 Uint8 Joy_GetStickData(int nStJoyId)
 {
-#ifdef __LIBRETRO__
-	if (nStJoyId == 1) return MXjoy0;
-	if (nStJoyId == 0) return MXjoy1;
-	return 0;
-#else
 	Uint8 nData = 0;
 	JOYREADING JoyReading;
 	int nSdlJoyId;
 	int nAxes; /* how many joystick axes are on the current selected SDL joystick? */
 
+#ifndef __LIBRETRO__
 	nSdlJoyId = ConfigureParams.Joysticks.Joy[nStJoyId].nJoyId;
 	nAxes = SDL_JoystickNumAxes(sdlJoystick[nSdlJoyId]);
+#endif
 
 	/* Are we emulating the joystick via the keyboard? */
 	if (ConfigureParams.Joysticks.Joy[nStJoyId].nJoystickMode == JOYSTICK_KEYBOARD)
@@ -218,6 +215,13 @@ Uint8 Joy_GetStickData(int nStJoyId)
 			nData = nJoyKeyEmu[nStJoyId];
 		}
 	}
+#ifdef __LIBRETRO__
+	else if (ConfigureParams.Joysticks.Joy[nStJoyId].nJoystickMode == JOYSTICK_REALSTICK)
+	{
+		if (nStJoyId == 1) nData = MXjoy0;
+		if (nStJoyId == 0) nData = MXjoy1;
+	}
+#else
 	else if (ConfigureParams.Joysticks.Joy[nStJoyId].nJoystickMode == JOYSTICK_REALSTICK
 	         && bJoystickWorking[nSdlJoyId])
 	{
@@ -276,6 +280,7 @@ Uint8 Joy_GetStickData(int nStJoyId)
 			}
 		}
 	}
+#endif
 
 	/* Ignore fire button every 8 frames if enabled autofire (for both cursor emulation and joystick) */
 	if (ConfigureParams.Joysticks.Joy[nStJoyId].bEnableAutoFire)
@@ -285,7 +290,6 @@ Uint8 Joy_GetStickData(int nStJoyId)
 	}
 
 	return nData;
-#endif
 }
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -312,7 +312,7 @@ void Main_WaitOnVbl(void)
 	Sint64 nDelay;
 
 #ifdef __LIBRETRO__
-if(pauseg==1)pause_select();
+if(pauseg==1)enter_gui();
 co_switch(mainThread);
 #if defined(WIIU) || defined(VITA)
 return;


### PR DESCRIPTION
Some games were not working the with joystick. The problem seemed to be that we had used IKBD_GetJoystickData to insert our joystick data, instead of further upstream at Joy_GetStickData, which has some other ways to be called besides just in that IKBD function. Games that used an alternate method were thus failing to get joystick readings.

This should fix issue #50 and I tested it with Altered Beast, Alien Syndrome and Time Bandit, which all previously didn't work.

While doing this, I also removed the joystick button mapping to select number of joysticks, which was never implemented properly and doesn't actually map to any Hatari setting properly as far as I can tell? Instead I turned 1 or 2 joysticks into a libretro option that enables/disables the second joystick through Hatari's config. It seems to be a good default to leave it on, since it does not appear to cause conflicts with the mouse normally, but with the option it can be turned off (and with per-game override) if the need arises.

Also saw a request for a space bar to controller mapping #46 which I put on R3. (Since start was freed up, I moved the Hatari GUI there, where it might be more intuitive, and put the virtual keyboard on X where it might be easier to find. Removed redundant tilde for GUI which conflicted with a key in use.)

Added start in GUI to exit from GUI so it works both ways now. (This also allows savestate restore to leave the GUI now.)

Added options to disable mouse/keyboard input in case they conflict with hotkeys or other things and you'd like to do input only from the gamepad.

(Also includes pull #67 which is just  a minor update to the internal savestate.)