### PR TITLE
Fix crash on Android.

### DIFF
--- a/libretro/jni/Android.mk
+++ b/libretro/jni/Android.mk
@@ -15,7 +15,7 @@ SOURCES_C :=
 
 include $(CORE_DIR)/Makefile.common
 
-COREFLAGS := -DANDROID -DAND -D__LIBRETRO__ $(INCFLAGS)
+COREFLAGS := -DANDROID -DLSB_FIRST -DAND -D__LIBRETRO__ $(INCFLAGS)
 
 GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
 ifneq ($(GIT_VERSION)," unknown")


### PR DESCRIPTION
Compiling without -DLSB_FIRST causes loading of TOS to fail.

This lead to crashes on Android due to standard behavior of Hatari which is to show built-in GUI when TOS loading fails, which again would then lead to retro_input polling before retro_input pointers were properly initialized.
