### PR TITLE
libretro: Allow overriding EXTERNAL_ZLIB

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -17,7 +17,7 @@ else ifneq ($(findstring win,$(shell uname -a)),)
 endif
 endif
 
-EXTERNAL_ZLIB = 0
+EXTERNAL_ZLIB ?= 0
 
 TARGET_NAME	:= hatari
 GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"


### PR DESCRIPTION
This allows for more easily cross compiling Linux armv7a and aarch64.