### PR TITLE
use OLD CPU

### DIFF
--- a/cmake/config-cmake.h
+++ b/cmake/config-cmake.h
@@ -89,7 +89,7 @@
 #cmakedefine ENABLE_DSP_EMU 1
 
 /* Define to 1 to enable WINUAE cpu  */
-#cmakedefine ENABLE_WINUAE_CPU 1
+//#cmakedefine ENABLE_WINUAE_CPU 1
 
 /* Define to 1 to use less memory - at the expense of emulation speed */
 #cmakedefine ENABLE_SMALL_MEM 1


### PR DESCRIPTION
Hatari team themselves suggest OLD CPU in Readme except Falcon mode. And it's a lot faster (compiled it like that some time ago and run full speed even on a Wii).