### PR TITLE
libretro: link the capsimage library when IPF support is asked for

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -225,8 +225,20 @@ ifneq ($(EXTERNAL_ZLIB), 1)
 ZLIB = -lz
 endif
 
+# IPF/CTR floppy images, through the SPS capsimage library. Off by default,
+# since neither the headers nor the library are in this tree:
+#
+#   make -f Makefile.libretro capsimg=1 \
+#        capssrc=/path/to/capsimg capslib=/path/to/capsimg/.libs
+#
+# capssrc is the capsimage SDK source tree (the one with Core/ and LibIPF/),
+# capslib the directory holding the built library; capslibname overrides its
+# name, which differs between SPS builds (capsimage, CAPSImg, CAPSImg_x64).
+CAPS_LIB =
 ifeq ($(capsimg), 1)
 PLATFLAGS += -DHAVE_CAPSIMAGE -DCAPSIMAGE_VERSION=5 -I$(capssrc)/LibIPF/ -I$(capssrc)/Core/
+capslibname ?= capsimage
+CAPS_LIB := $(if $(capslib),-L$(capslib) ,)-l$(capslibname)
 endif
 
 ifeq ($(DEBUG), 1)
@@ -259,7 +271,7 @@ $(TARGET): $(OBJECTS)
 ifeq ($(STATIC_LINKING_LINK),1)
 	$(AR) rcs $@ $(OBJECTS) 
 else
-	$(CC) $(CFLAGS) $(INCFLAGS) $(LDFLAGS) $(OBJECTS) -o $@ -lm $(ZLIB) $(SHARED)
+	$(CC) $(CFLAGS) $(INCFLAGS) $(LDFLAGS) $(OBJECTS) -o $@ -lm $(ZLIB) $(CAPS_LIB) $(SHARED)
 endif
 
 %.o: %.c

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -237,6 +237,9 @@ endif
 CAPS_LIB =
 ifeq ($(capsimg), 1)
 PLATFLAGS += -DHAVE_CAPSIMAGE -DCAPSIMAGE_VERSION=5 -I$(capssrc)/LibIPF/ -I$(capssrc)/Core/
+# The SDK headers spell every entry point __cdecl, which only MSVC knows;
+# the library's own build defines it away and consumers have to do the same.
+PLATFLAGS += -D__cdecl=
 capslibname ?= capsimage
 CAPS_LIB := $(if $(capslib),-L$(capslib) ,)-l$(capslibname)
 endif


### PR DESCRIPTION
Completes what #80 set out to do, without the parts of it that were collateral.

`capsimg=1` already exists here: it defines `HAVE_CAPSIMAGE` / `CAPSIMAGE_VERSION=5` and puts `$(capssrc)/LibIPF` and `$(capssrc)/Core` on the include path. What it never did was link anything, so `src/floppy_ipf.c` compiled and the core then failed at link time on `CAPSInit`, `CAPSLockImage` and the rest. This adds the missing `-l` (with an optional `-L`), which is the one thing #80 was really about:

```
make -f Makefile.libretro capsimg=1 \
     capssrc=/path/to/capsimg capslib=/path/to/capsimg/.libs
```

`capslibname` overrides the library name, because the SPS builds do not agree on it — `capsimage` on Linux, `CAPSImg` / `CAPSImg_x64` on Windows.

Left out on purpose, compared to #80:

- the prebuilt `CAPSImg.lib` binaries and the vendored SDK headers under `src/capsimg_binary/` and `src/ipflib42_*`. The SDK is not ours to ship, and a Windows import library does not help any other target; pointing `capssrc` at it works the same.
- the rest of that diff. It was written against a much older `Makefile.libretro` and, applied today, would take `GIT_VERSION`, `EXTERNAL_ZLIB`, the console `STATIC_LINKING` branches, `-Wl,--as-needed` and `.PHONY: clean` back out with it.

Off by default, so nothing changes for the normal build.