### PR TITLE
libretro: make floppy_ipf.c build against the real capsimage 5 headers

### DIFF
--- a/src/floppy_ipf.c
+++ b/src/floppy_ipf.c
@@ -27,7 +27,10 @@ const char floppy_ipf_fileid[] = "Hatari floppy_ipf.c : " __DATE__ " " __TIME__;
 
 #ifdef HAVE_CAPSIMAGE
 #if CAPSIMAGE_VERSION == 5
+#include <stdint.h>
 #include <CapsLibAll.h>
+#define CapsLong	SDWORD
+#define CapsULong	UDWORD
 #else
 #include <caps/fdc.h>
 #define CAPS_LIB_RELEASE	4


### PR DESCRIPTION
Follow-up to #127, on the back of https://github.com/libretro/hatari/pull/127#issuecomment-5557630538: with `capsimg=1` the core links now, but `src/floppy_ipf.c` does not actually compile against the stock SPS SDK headers. Two things are missing, and both predate #127:

- The file spells the FDC callback state and the `CAPSLockImageMemory` length `CapsLong` / `CapsULong`. No capsimage release defines those — modern Hatari defines them itself in `src/floppies/ipf.c` (`#define CapsLong SDWORD`, `#define CapsULong UDWORD`). Same two lines here.
- The SDK's `Core/CommonTypes.h` builds its typedefs on `uint8_t` and friends but never includes `<stdint.h>`. Without it `UBYTE` decays to `int`, so `PUBYTE` is `int *` and the buffer passed to `CAPSLockImageMemory` is rejected as an incompatible pointer type.

Tested on aarch64 Linux (gcc 15) against an unmodified `spsdeclib_5.1_source.zip`, built with its own `CAPSImg/configure`:

```
make -f Makefile.libretro capsimg=1 \
     capssrc=/path/to/capsimg_source_linux_macosx \
     capslib=/path/to/capsimg_source_linux_macosx/CAPSImg
```

That produces `hatari2014_libretro.so` with `NEEDED libcapsimage.so.5`. One wrinkle worth knowing, not something to fix in the tree: the SPS build leaves only `libcapsimage.so.5.1`, no development symlink, so `-lcapsimage` finds nothing until you either add `libcapsimage.so` next to it or point `capslibname` at the name your build actually uses. FrodeSolheim's and rsn8887's trees are the same sources with a different build system, so they behave identically here.

Still off by default; nothing changes for the normal build.