### PR TITLE
file: take the frontend's device-prefixed paths as absolute

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -938,12 +938,24 @@ void File_MakeAbsoluteName(char *pFileName)
 			free(pTempName);
 			return;
 		}
+		/* File_AddSlashToEndFileName() writes two bytes past the end of what
+		 * it is given, so leave it room rather than trusting the length of
+		 * whatever the platform's getcwd() returned.
+		 */
+		if (strlen(pTempName) >= FILENAME_MAX - 2)
+		{
+			free(pTempName);
+			return;
+		}
 		File_AddSlashToEndFileName(pTempName);
 		outpos = strlen(pTempName);
 	}
 
-	/* Now filter out the relative paths "./" and "../" */
-	while (pFileName[inpos] != 0 && outpos < FILENAME_MAX)
+	/* Now filter out the relative paths "./" and "../".
+	 * The bound leaves room for the terminator written after the loop, which
+	 * at outpos == FILENAME_MAX would have been one byte past the buffer.
+	 */
+	while (pFileName[inpos] != 0 && outpos < FILENAME_MAX - 1)
 	{
 		if (pFileName[inpos] == '.' && pFileName[inpos+1] == PATHSEP)
 		{
@@ -992,7 +1004,7 @@ void File_MakeAbsoluteName(char *pFileName)
 		else
 		{
 			/* Copy until next slash or end of input string */
-			while (pFileName[inpos] != 0 && outpos < FILENAME_MAX)
+			while (pFileName[inpos] != 0 && outpos < FILENAME_MAX - 1)
 			{
 				pTempName[outpos++] = pFileName[inpos++];
 				if (pFileName[inpos - 1] == PATHSEP)

--- a/src/file.c
+++ b/src/file.c
@@ -149,6 +149,23 @@ static bool File_IsRootFileName(const char *pszFileName)
 		return true;
 #endif
 
+#ifdef LIBRETRO
+	/* The console ports name their devices rather than rooting everything at
+	 * '/': the frontend hands the core "ux0:/data/retroarch/system" on the
+	 * Vita, "sdmc:/" on the 3DS and the Switch, "ms0:/" on the PSP. Those are
+	 * absolute names. Taken for relative ones they get the working directory
+	 * pasted in front of them, which is how a tos.img that is there and
+	 * readable ends up as "Can not load TOS file".
+	 */
+	{
+		const char *colon = strchr(pszFileName, ':');
+		const char *sep = strchr(pszFileName, PATHSEP);
+
+		if (colon && colon != pszFileName && (!sep || colon < sep))
+			return true;
+	}
+#endif
+
 	return false;
 }
 


### PR DESCRIPTION
`File_IsRootFileName()` knows about `/`, Windows drive letters and three Wii prefixes. The console ports name their devices instead: RetroArch hands the core `ux0:/data/retroarch/system` on the Vita, `uma0:...` on the second card, `sdmc:/` on the 3DS and the Switch, `ms0:/` on the PSP. None of those look absolute to that function, so `Configuration_Apply()` runs `File_MakeAbsoluteName()` over them and pastes the working directory in front.

The result is #126. The `tos.img` is there and readable - the core's own `File_Exists()` finds it through the VFS, which is why the BIOS check passes and nothing is logged - and then `TOS_Init()` is handed a name that no longer points at it. The 2014 core did not have this problem: it never took that path, it had `ux0:` written into `paths.c` by hand.

Measured on the core built from this branch, with a minimal libretro frontend that prints `ConfigureParams.Rom.szTosImageFileName` after `retro_init`, system directory `uma0:sys`:

```
before: /tmp/hharness/uma0:sys/tos.img
after:  uma0:sys/tos.img
```

Ordinary absolute (`/tmp/hsys`) and relative (`../hsys`) host paths come out identically before and after, and `dir/we:ird.st` - a colon after the first separator - is still relative.

The second commit closes two out-of-bounds writes in `File_MakeAbsoluteName()` itself, both reached through a long or unusual working directory, which is what the console ports have:

- the copy loops stop at `outpos == FILENAME_MAX`, and the terminator afterwards is written at `pTempName[FILENAME_MAX]` - one past the allocation - then `strcpy()`'d back into a caller buffer of the same size;
- `File_AddSlashToEndFileName()` writes two bytes past the end of the string it is given, and nothing checks how long `getcwd()` made it.

That is the shape that fits the rest of #126: the reported name was binary junk, and the core crashed rather than stopping at "Can not load TOS file".

What I could not do is run it on a Vita. Verified here: it builds, and the paths resolve as above on Linux.
