### PR TITLE
str: do not take the frontend's LC_NUMERIC with us on Windows

### DIFF
--- a/src/str.c
+++ b/src/str.c
@@ -430,7 +430,14 @@ void Str_Init(void)
 		mapUnicodeToAtari[mapAtariToUnicode[i] & 511] = i;
 	}
 
-#if defined(WIN32) || defined(USE_LOCALE_CHARSET)
+#if defined(LIBRETRO) && (defined(WIN32) || defined(USE_LOCALE_CHARSET))
+	/* Use LC_CTYPE instead of LC_ALL so character handling follows the
+	 * user's locale without changing numeric formatting, preventing
+	 * locale-specific decimal separators (e.g. 1,0000) in RetroArch
+	 * configuration files.
+	 */
+	setlocale(LC_CTYPE, "");
+#elif defined(WIN32) || defined(USE_LOCALE_CHARSET)
 	/* Change libc from default "C" locale to one
 	 * specified by the program environment. Needed
 	 * only for Windows, as Unix based OSes (are


### PR DESCRIPTION
`Str_Init()` calls `setlocale(LC_ALL, "")` on Windows so that the Atari character set can be converted to whatever the host uses. Everything it does that for - `wctomb()`, `mbtowc()`, `MB_CUR_MAX` - is `LC_CTYPE`. `LC_ALL` takes `LC_NUMERIC` along with it, and in a core the process belongs to the frontend.

On a machine whose locale writes a decimal comma, that turns two things in RetroArch inside out from the moment content is loaded:

- `#pragma parameter DO_TEST "..." 0.0 0.0 12.0 1.0` is read with `strtod()` in `gfx/drivers_shader/slang_process.c`. The first call now stops at the `.`, the second is handed `".0 0.0 12.0 1.0"` and fails, and the preset is dropped whole with `Invalid #pragma parameter line`;
- config floats are written with `snprintf("%f")`, so `retroarch.cfg` gets `input_axis_threshold = 0,500000`, which RetroArch's own locale-independent reader truncates to `0` on the next start - after which input behaves as if every axis were held.

Measured under `sk_SK.utf8`, running RetroArch's exact `strtod` sequence over that pragma line:

```
after setlocale(LC_ALL,"")   | 0 | field 2 REJECTED at ".0 0.0 12.0 1.0" || snprintf("%f",0.5) = 0,500000
after setlocale(LC_CTYPE,"") | 0 | 0 | 12 | 1                            || snprintf("%f",0.5) = 0.500000
```

This is #131, and it accounts for every observation in that thread: Windows only, because the call is behind `#if defined(WIN32)`; only the Atari cores, because they are the ones calling it; not the 2014 core, which never calls `Str_Init()` at all; hatariB too, which does; and not reproducible for anyone whose locale writes a decimal point, which is why it looked like a RetroArch regression at first - it is not, RetroArch parses those lines correctly in the locale it is entitled to expect.

Only the libretro build changes. Standalone Hatari owns its process and keeps `LC_ALL`.

Not verified on Windows hardware - I have none here. What is verified: the core builds, and the locale behaviour above is measured rather than assumed.
