### PR TITLE
Vita: load the TOS image from a device-prefixed path instead of quitting the frontend

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1009,6 +1009,16 @@ void Emu_uninit()
        Main_UnInit();
 }
 
+// Errors raised on the emulator thread used to reach stderr and nowhere else,
+// which on a console means nowhere at all: a core that gave up during start-up
+// looked to the user like the frontend quitting for no reason. Give that code
+// the frontend's log.
+void retro_log_error(const char *msg)
+{
+   if (log_cb)
+      log_cb(RETRO_LOG_ERROR, "%s\n", msg);
+}
+
 void retro_shutdown_hatari(void)
 {
    log_cb(RETRO_LOG_INFO, "SHUTDOWN\n");

--- a/src/file.c
+++ b/src/file.c
@@ -158,6 +158,20 @@ static bool File_IsRootFileName(const char *pszFileName)
 		return true;
 #endif
 
+#ifdef __LIBRETRO__
+	/* Console(s) may include the name of the devices rather than everything being
+	 * at '/': thus the frontend hands the core something like
+	 * "ux0:/data/retroarch/system"
+	 */
+	{
+		const char *colon = strchr(pszFileName, ':');
+		const char *sep = strchr(pszFileName, PATHSEP);
+
+		if (colon && colon != pszFileName && (!sep || colon < sep))
+			return true;
+	}
+#endif
+
 	return false;
 }
 

--- a/src/file.c
+++ b/src/file.c
@@ -854,12 +854,24 @@ void File_MakeAbsoluteName(char *pFileName)
 			free(pTempName);
 			return;
 		}
+		/* File_AddSlashToEndFileName() writes two bytes past the end of what
+		 * it is given, so leave it room rather than trusting the length of
+		 * whatever the platform's getcwd() returned.
+		 */
+		if (strlen(pTempName) >= FILENAME_MAX - 2)
+		{
+			free(pTempName);
+			return;
+		}
 		File_AddSlashToEndFileName(pTempName);
 		outpos = strlen(pTempName);
 	}
 
-	/* Now filter out the relative paths "./" and "../" */
-	while (pFileName[inpos] != 0 && outpos < FILENAME_MAX)
+	/* Now filter out the relative paths "./" and "../".
+	 * The bound leaves room for the terminator written after the loop, which
+	 * at outpos == FILENAME_MAX would have been one byte past the buffer.
+	 */
+	while (pFileName[inpos] != 0 && outpos < FILENAME_MAX - 1)
 	{
 		if (pFileName[inpos] == '.' && pFileName[inpos+1] == PATHSEP)
 		{
@@ -908,7 +920,7 @@ void File_MakeAbsoluteName(char *pFileName)
 		else
 		{
 			/* Copy until next slash or end of input string */
-			while (pFileName[inpos] != 0 && outpos < FILENAME_MAX)
+			while (pFileName[inpos] != 0 && outpos < FILENAME_MAX - 1)
 			{
 				pTempName[outpos++] = pFileName[inpos++];
 				if (pFileName[inpos - 1] == PATHSEP)

--- a/src/main.c
+++ b/src/main.c
@@ -743,6 +743,15 @@ static void Main_Init(void)
 		fprintf(stderr, "Failed to load TOS image!\n");
 		SDL_Quit();
 #ifdef __LIBRETRO__
+	{
+		/* stderr goes nowhere on most of the platforms this core is built
+		 * for, so say it where the user can actually read it back. */
+		char sRetroMsg[FILENAME_MAX + 64];
+		extern void retro_log_error(const char *msg);
+		snprintf(sRetroMsg, sizeof(sRetroMsg), "Failed to load TOS image '%s'",
+		         ConfigureParams.Rom.szTosImageFileName);
+		retro_log_error(sRetroMsg);
+	}
 retro_shutdown_hatari();
 #endif 
 		exit(-2);


### PR DESCRIPTION
Fixes #135: on a PS Vita the Hatari2014 core takes RetroArch down to the LiveArea as soon as content is launched.

From the reporter's log the core asks the frontend to quit, one line after the disk goes in:

```
[libretro INFO] Disk (1) inserted into drive A : uma0:/Retroarch/ROMS/...stx
[libretro INFO] WRAP EMU THD
...
[libretro INFO] SHUTDOWN
[INFO] [Environ] SHUTDOWN.
```

That is `Main_Init()` giving up on the TOS image (`src/main.c`: "Failed to load TOS image!" → `retro_shutdown_hatari()` → `exit(-2)`), and the reason is the path. The core's own `file_exists()` finds `uma0:/Retroarch/system/tos.img` before the emulator starts, but `Configuration_Apply()` then runs it through `File_MakeAbsoluteName()`, and `File_IsRootFileName()` only knows `/`, Windows drive letters and the three Wii prefixes. A Vita mount point is neither, so the name counts as relative and gets the working directory pasted in front of it.

This is the same bug as #126, fixed for the current core in #132; this branch's core never got it. The first two commits are that fix, ported:

* device-prefixed names (`ux0:`, `uma0:`, `app0:` on the Vita, `sdmc:` on the 3DS and Switch, `ms0:` on the PSP) count as absolute;
* the two out-of-bounds writes in `File_MakeAbsoluteName()` that a long or unusual working directory reaches - which is exactly what the console ports have.

The third commit is why the log said nothing about it: the message went to `stderr`, which on a console goes nowhere, so the user saw the frontend closing itself with no explanation. It goes through the frontend's log now, with the path it tried.

Built for `platform=vita` in the vitasdk container the buildbot job uses (`hatari2014_libretro_vita.a`, `retro_run` present), and the default Linux core still builds. I have no Vita to run it on, so the reporter's confirmation is still worth waiting for.
